### PR TITLE
Credit project contributors

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,8 +1,8 @@
 # Contributors
 
 Dareplane is developed and maintained as a collaborative, open-source effort.
-We are grateful to everyone who has contributed code, documentation, ideas, and
-feedback to the project across its many modules.
+We are grateful to everyone who has contributed code, documentation, ideas,
+and feedback to the project across its many modules.
 
 ## Project contributors
 


### PR DESCRIPTION
Attribute the people listed in CONTRIBUTORS.md as commit co-authors so they appear in the GitHub contributors sidebar.